### PR TITLE
Fixes #2, paket and sln

### DIFF
--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -43,25 +43,22 @@
     <!-- Step 1 Check if lockfile is properly restored -->
     <PropertyGroup>
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <NoWarn>$(NoWarn);NU1603;NU1604;NU1605;NU1608</NoWarn>
+      <NoWarn>$(NoWarn);NU1603</NoWarn>
     </PropertyGroup>
 
     <!-- Because ReadAllText is slow on osx/linux, try to find shasum and awk -->
     <PropertyGroup>
-      <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketRestoreCacheFile)" | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
-      <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum "$(PaketLockFilePath)" | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
+        <PaketRestoreCachedHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreCachedHasher)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketRestoreCacheFile) | /usr/bin/awk '{ print $1 }'</PaketRestoreCachedHasher>
+        <PaketRestoreLockFileHasher Condition="'$(OS)' != 'Windows_NT' And '$(PaketRestoreLockFileHash)' == '' And Exists('/usr/bin/shasum') And Exists('/usr/bin/awk')">/usr/bin/shasum $(PaketLockFilePath) | /usr/bin/awk '{ print $1 }'</PaketRestoreLockFileHasher>
     </PropertyGroup>
 
     <!-- If shasum and awk exist get the hashes -->
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreCachedHasher)' != '' " Command="$(PaketRestoreCachedHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreCachedHash" />
     </Exec>
     <Exec StandardOutputImportance="Low" Condition=" '$(PaketRestoreLockFileHasher)' != '' " Command="$(PaketRestoreLockFileHasher)" ConsoleToMSBuild='true'>
-      <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
+        <Output TaskParameter="ConsoleOutput" PropertyName="PaketRestoreLockFileHash" />
     </Exec>
-
-    <!-- Debug whats going on -->
-    <Message Importance="low" Text="calling paket restore with targetframework=$(TargetFramework) targetframeworks=$(TargetFrameworks)" />
 
     <PropertyGroup Condition="Exists('$(PaketRestoreCacheFile)') ">
       <!-- if no hash has been done yet fall back to just reading in the files and comparing them -->
@@ -72,22 +69,11 @@
       <PaketRestoreRequired Condition=" '$(PaketRestoreLockFileHash)' == '' ">true</PaketRestoreRequired>
     </PropertyGroup>
 
-    <PropertyGroup Condition="'$(PaketPropsVersion)' != '5.174.2' ">
-      <PaketRestoreRequired>true</PaketRestoreRequired>
-    </PropertyGroup>
-
     <!-- Do a global restore if required -->
     <Exec Command='$(PaketBootStrapperCommand)' Condition="Exists('$(PaketBootStrapperExePath)') AND !(Exists('$(PaketExePath)'))" ContinueOnError="false" />
     <Exec Command='$(PaketCommand) restore' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- Step 2 Detect project specific changes -->
-    <ItemGroup>
-      <MyTargetFrameworks Condition="'$(TargetFramework)' != '' " Include="$(TargetFramework)"></MyTargetFrameworks>
-      <!-- Don't include all frameworks when msbuild explicitly asks for a single one -->
-      <MyTargetFrameworks Condition="'$(TargetFrameworks)' != '' AND '$(TargetFramework)' == '' " Include="$(TargetFrameworks)"></MyTargetFrameworks>
-      <PaketResolvedFilePaths Include="@(MyTargetFrameworks -> '$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).%(Identity).paket.resolved')"></PaketResolvedFilePaths>
-    </ItemGroup>
-    <Message Importance="low" Text="MyTargetFrameworks=@(MyTargetFrameworks) PaketResolvedFilePaths=@(PaketResolvedFilePaths)" />
     <PropertyGroup>
       <PaketReferencesCachedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).paket.references.cached</PaketReferencesCachedFilePath>
       <!-- MyProject.fsproj.paket.references has the highest precedence -->
@@ -96,9 +82,7 @@
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\$(MSBuildProjectName).paket.references</PaketOriginalReferencesFilePath>
       <!-- paket.references -->
       <PaketOriginalReferencesFilePath Condition=" !Exists('$(PaketOriginalReferencesFilePath)')">$(MSBuildProjectDirectory)\paket.references</PaketOriginalReferencesFilePath>
-
-      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
-      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
+      <PaketResolvedFilePath>$(MSBuildProjectDirectory)\obj\$(MSBuildProjectFile).$(TargetFramework).paket.resolved</PaketResolvedFilePath>
       <PaketRestoreRequired>true</PaketRestoreRequired>
       <PaketRestoreRequiredReason>references-file-or-cache-not-found</PaketRestoreRequiredReason>
     </PropertyGroup>
@@ -117,40 +101,32 @@
     </PropertyGroup>
 
     <!-- Step 2 b detect relevant changes in project file (new targetframework) -->
-    <PropertyGroup Condition=" '$(DoAllResolvedFilesExist)' != 'true' ">
+    <PropertyGroup Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' ">
       <PaketRestoreRequired>true</PaketRestoreRequired>
-      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)' or '$(TargetFrameworks)' files @(PaketResolvedFilePaths)</PaketRestoreRequiredReason>
+      <PaketRestoreRequiredReason>target-framework '$(TargetFramework)'</PaketRestoreRequiredReason>
     </PropertyGroup>
 
     <!-- Step 3 Restore project specific stuff if required -->
     <Message Condition=" '$(PaketRestoreRequired)' == 'true' " Importance="low" Text="Detected a change ('$(PaketRestoreRequiredReason)') in the project file '$(MSBuildProjectFullPath)', calling paket restore" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFrameworks)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' == '' " ContinueOnError="false" />
-    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)" --target-framework "$(TargetFramework)"' Condition=" '$(PaketRestoreRequired)' == 'true' AND '$(TargetFramework)' != '' " ContinueOnError="false" />
+    <Exec Command='$(PaketCommand) restore --project "$(MSBuildProjectFullPath)"' Condition=" '$(PaketRestoreRequired)' == 'true' " ContinueOnError="false" />
 
     <!-- This shouldn't actually happen, but just to be sure. -->
-    <PropertyGroup>
-      <DoAllResolvedFilesExist>false</DoAllResolvedFilesExist>
-      <DoAllResolvedFilesExist Condition="Exists(%(PaketResolvedFilePaths.Identity))">true</DoAllResolvedFilesExist>
-    </PropertyGroup>
-    <Error Condition=" '$(DoAllResolvedFilesExist)' != 'true' AND '$(ResolveNuGetPackages)' != 'False' " Text="One Paket file '@(PaketResolvedFilePaths)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
+    <Error Condition=" !Exists('$(PaketResolvedFilePath)') AND '$(TargetFramework)' != '' AND '$(ResolveNuGetPackages)' != 'False' " Text="Paket file '$(PaketResolvedFilePath)' is missing while restoring $(MSBuildProjectFile). Please delete 'paket-files/paket.restore.cached' and call 'paket restore'." />
 
     <!-- Step 4 forward all msbuild properties (PackageReference, DotNetCliToolReference) to msbuild -->
-    <ReadLinesFromFile Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketResolvedFilePaths)' != ''" File="%(PaketResolvedFilePaths.Identity)" >
+    <ReadLinesFromFile Condition="Exists('$(PaketResolvedFilePath)')" File="$(PaketResolvedFilePath)" >
       <Output TaskParameter="Lines" ItemName="PaketReferencesFileLines"/>
     </ReadLinesFromFile>
 
-    <ItemGroup Condition="($(DesignTimeBuild) != true OR '$(PaketPropsLoaded)' != 'true') AND '@(PaketReferencesFileLines)' != '' " >
+    <ItemGroup Condition=" Exists('$(PaketResolvedFilePath)') AND '@(PaketReferencesFileLines)' != '' " >
       <PaketReferencesFileLinesInfo Include="@(PaketReferencesFileLines)" >
         <PackageName>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[0])</PackageName>
         <PackageVersion>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[1])</PackageVersion>
         <AllPrivateAssets>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[4])</AllPrivateAssets>
-        <CopyLocal>$([System.String]::Copy('%(PaketReferencesFileLines.Identity)').Split(',')[5])</CopyLocal>
       </PaketReferencesFileLinesInfo>
       <PackageReference Include="%(PaketReferencesFileLinesInfo.PackageName)">
         <Version>%(PaketReferencesFileLinesInfo.PackageVersion)</Version>
-        <PrivateAssets Condition=" ('%(PaketReferencesFileLinesInfo.AllPrivateAssets)' == 'true') Or ('$(PackAsTool)' == 'true') ">All</PrivateAssets>
-        <ExcludeAssets Condition="%(PaketReferencesFileLinesInfo.CopyLocal) == 'false'">runtime</ExcludeAssets>
-        <Publish Condition=" '$(PackAsTool)' == 'true' ">true</Publish>
+        <PrivateAssets Condition="%(PaketReferencesFileLinesInfo.AllPrivateAssets) == 'true'">All</PrivateAssets>
       </PackageReference>
     </ItemGroup>
 
@@ -207,8 +183,8 @@
 
     <ConvertToAbsolutePath Condition="@(_NuspecFiles) != ''" Paths="@(_NuspecFiles)">
       <Output TaskParameter="AbsolutePaths" PropertyName="NuspecFileAbsolutePath" />
-    </ConvertToAbsolutePath>
-
+    </ConvertToAbsolutePath>      
+        
 
     <!-- Call Pack -->
     <PackTask Condition="$(UseNewPack)"

--- a/src/FsCassy.Tests/InMemTests.fs
+++ b/src/FsCassy.Tests/InMemTests.fs
@@ -14,10 +14,34 @@ module Samples =
     open Statement
 
     type X = {x:int}
+    type T = {w:string; x:int; y:int; z:int}
+    type en = | Zero = 0 | One = 1
+    type E = { e:en }
+
     let exampleWhere : Statement<X,_> =
             table
         >>= where (Quote.X(fun x -> x.x = 0)) 
         >>= read
+
+    let exampleWhereNone : Statement<X,_> =
+            table
+        >>= where (Quote.X(fun x -> x.x = 10)) 
+        >>= read
+
+    let exampleFind : Statement<X,_> =
+            table
+        >>= where (Quote.X(fun x -> x.x = 0)) 
+        >>= find
+
+    let exampleFindConversion : Statement<E,_> =
+            table
+        >>= where (Quote.X(fun e -> int e.e = 0 )) 
+        >>= find
+
+    let exampleFindNone : Statement<X,_> =
+            table
+        >>= where (Quote.X(fun x -> x.x = 10)) 
+        >>= find
 
     let exampleTake : Statement<X,_> =
             table
@@ -32,7 +56,7 @@ module Samples =
     let exampleUpdate : Statement<X,_> =
             table
         >>= where (Quote.X(fun x -> x.x = 0))
-        >>= select (Quote.X(fun x -> { x with x = 10}))
+        >>= select (Quote.X(fun x -> { x with x = 10 }))
         >>= update
         >>= withConsistency Consistency.Any
         >>= execute
@@ -40,8 +64,16 @@ module Samples =
     let exampleUpdateIf : Statement<X,_> =
             table
         >>= where (Quote.X(fun x -> x.x = 0))
-        >>= select (Quote.X(fun x -> { x with x = 10}))
+        >>= select (Quote.X(fun x -> { x with x = 10 }))
         >>= updateIf (Quote.X(fun x -> x.x = 0))
+        >>= withConsistency Consistency.Any
+        >>= execute
+
+    let exampleUpdateNew : Statement<T,_> =
+            table
+        >>= where (Quote.X(fun t -> t.x = 7 && t.y = 8))
+        >>= select (Quote.X(fun t -> { t with z = 9 }))
+        >>= update
         >>= withConsistency Consistency.Any
         >>= execute
 
@@ -74,9 +106,30 @@ let ``InMem reads``() =
     |> Async.RunSynchronously |> List.ofSeq =! xs
 
 [<Test>]
-let ``InMem where``() = 
+let ``InMem reads where``() = 
     Samples.exampleWhere |> InMem.Interpreter.execute (ResizeArray xs) 
     |> Async.RunSynchronously |> List.ofSeq =! [{x=0}; {x=0}]
+
+[<Test>]
+let ``InMem reads no-where``() = 
+    Samples.exampleWhereNone |> InMem.Interpreter.execute (ResizeArray xs) 
+    |> Async.RunSynchronously |> List.ofSeq =! []
+
+[<Test>]
+let ``InMem finds where``() = 
+    Samples.exampleFind |> InMem.Interpreter.execute (ResizeArray xs) 
+    |> Async.RunSynchronously =! Some {x=0}
+
+[<Test>]
+let ``InMem finds no-where converted``() = 
+    let xs = ResizeArray [ { e = en.One } ]
+    Samples.exampleFindConversion |> InMem.Interpreter.execute (ResizeArray xs) 
+    |> Async.RunSynchronously =! None
+
+[<Test>]
+let ``InMem finds no-where``() = 
+    Samples.exampleFindNone |> InMem.Interpreter.execute (ResizeArray xs) 
+    |> Async.RunSynchronously =! None
 
 [<Test>]
 let ``InMem takes``() = 
@@ -108,6 +161,14 @@ let ``InMem updatesIf``() =
     Samples.exampleUpdateIf |> InMem.Interpreter.execute xs 
     |> Async.RunSynchronously
     xs.Contains {x=10} =! true
+
+[<Test>]
+let ``InMem updatesNew``() = 
+    let xs = ResizeArray [ { w = "0"; x=1; y=2; z=3 }; { w = "0"; x=2; y=3; z=4 }; { w = "0"; x=3; y=4; z=5 } ]
+    Samples.exampleUpdateNew |> InMem.Interpreter.execute xs 
+    |> Async.RunSynchronously
+    xs.Count =! 4
+    xs.Contains { w = null; x=7; y=8; z=9 } =! true
 
 [<Test>]
 let ``InMem deletes``() = 

--- a/src/FsCassy.sln
+++ b/src/FsCassy.sln
@@ -1,6 +1,7 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 15
+VisualStudioVersion = 15.0.28010.2036
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".paket", ".paket", "{63297B98-5CED-492C-A5B7-A5B4F73CF142}"
 	ProjectSection(SolutionItems) = preProject
 		paket.dependencies = paket.dependencies
@@ -28,13 +29,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "content", "content", "{8E6D
 		docs\content\tutorial.fsx = docs\content\tutorial.fsx
 	EndProjectSection
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "FsCassy", "FsCassy\FsCassy.fsproj", "{D333F8C5-1914-4955-8EC1-5777D615B75E}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsCassy", "FsCassy\FsCassy.fsproj", "{D333F8C5-1914-4955-8EC1-5777D615B75E}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "FsCassy.Tests", "FsCassy.Tests\FsCassy.Tests.fsproj", "{91C4288D-997D-4ABA-9BDF-B8FF33781B8B}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsCassy.Tests", "FsCassy.Tests\FsCassy.Tests.fsproj", "{91C4288D-997D-4ABA-9BDF-B8FF33781B8B}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "FsCassy.Hopac", "FsCassy.Hopac\FsCassy.Hopac.fsproj", "{D333F8C6-1914-4955-8EC1-5777D615B75E}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsCassy.Hopac", "FsCassy.Hopac\FsCassy.Hopac.fsproj", "{D333F8C6-1914-4955-8EC1-5777D615B75E}"
 EndProject
-Project("{f2a71f9b-5d33-465a-a702-920d77279786}") = "FsCassy.Hopac.Tests", "FsCassy.Hopac.Tests\FsCassy.Hopac.Tests.fsproj", "{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FsCassy.Hopac.Tests", "FsCassy.Hopac.Tests\FsCassy.Hopac.Tests.fsproj", "{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,10 +55,10 @@ Global
 		{D333F8C6-1914-4955-8EC1-5777D615B75E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D333F8C6-1914-4955-8EC1-5777D615B75E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D333F8C6-1914-4955-8EC1-5777D615B75E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{91C4288e-997D-4ABA-9BDF-B8FF33781B8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{91C4288e-997D-4ABA-9BDF-B8FF33781B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{91C4288e-997D-4ABA-9BDF-B8FF33781B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{91C4288e-997D-4ABA-9BDF-B8FF33781B8B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91C4288E-997D-4ABA-9BDF-B8FF33781B8B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -65,5 +66,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{83F16175-43B1-4C90-A1EE-8E351C33435D} = {A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}
 		{8E6D5255-776D-4B61-85F9-73C37AA1FB9A} = {A6A6AF7D-D6E3-442D-9B1E-58CC91879BE1}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {77A3514B-2D3A-4DEA-895D-9B6E7DCC1495}
 	EndGlobalSection
 EndGlobal

--- a/src/FsCassy/InMem.fs
+++ b/src/FsCassy/InMem.fs
@@ -3,18 +3,53 @@ module FsCassy.InMem
 open System
 open System.Linq
 open System.Linq.Expressions
-open System.Threading.Tasks
 
 /// Executes statements on a ResizeArray
 module Interpreter =
-    open System.Threading.Tasks
     open System.Collections.Generic
+    open System.Runtime.Serialization
+    
+    type Selection<'t> = 
+        | New of 't
+        | Existing of int*'t
+    module Selection =
+        let existing = function | Existing (i,v) -> Some (i,v) | New _ -> None
+        let filterExistingValue f = function | New _ -> false | Existing (_,v) -> f v
+        let filterExistingIndex f = function | New _ -> false | Existing (i,_) -> f i
+        let map f = function | Existing (i,v) -> Existing (i, f v) | New v -> New (f v)
+        let iterExisting f = function | Existing (i,v) -> f (i, v) | New v -> ()
+
+    let private mkDefault (x:Expression<Func<'t,bool>>) =
+        let destType = x.Parameters.[0].Type
+        let rec parseMemberValues : (Expression * Expression) -> (string * obj) list =
+            function
+            | (:? BinaryExpression as be1), (:? BinaryExpression as be2) ->
+                ((be1.Left, be1.Right) |> parseMemberValues) @ ((be2.Left, be2.Right) |> parseMemberValues)
+
+            | (:? MemberExpression as me), (:? ConstantExpression as ce)
+            | (:? ConstantExpression as ce), (:? MemberExpression as me) -> [ me.Member.Name, ce.Value ]
+
+            | (:? UnaryExpression as ue), (:? ConstantExpression as ce)
+            | (:? ConstantExpression as ce), (:? UnaryExpression as ue) -> (ue.Operand |> unbox<MemberExpression>, ce) |> parseMemberValues // [ (unbox<MemberExpression> ue.Operand).Member.Name, ce.Value ]
+
+            | e1, e2 -> failwith <| sprintf "Unsupported binary expression: %O %O" e1 e2
+
+        let queryValues = match x.Body with | :? BinaryExpression as be -> (be.Left, be.Right) |> parseMemberValues | e -> failwith <| sprintf "Unsupported root expression %O" e
+        let initValues =
+            FSharp.Reflection.FSharpType.GetRecordFields destType
+            |> Array.map (fun pi -> 
+                queryValues 
+                |> List.tryFind (fun (n, _) -> n = pi.Name)
+                |> Option.map snd 
+                |> Option.defaultValue (try FormatterServices.GetUninitializedObject pi.PropertyType with | _ -> null))
+
+        unbox<'t> <| FSharp.Reflection.FSharpValue.MakeRecord(destType, initValues)
 
     [<Struct>]
     type InterpretationState<'t> = 
         | Array of array:'t ResizeArray 
         | Query of query:Async<IEnumerable<'t>>
-        | Selection of selection:Async<IEnumerable<int*'t>>
+        | Selection of selection:Async<IEnumerable<Selection<'t>>>
         | Command of command:Async<unit>
         | Done
 
@@ -47,25 +82,28 @@ module Interpreter =
             | Clause(Where(x, mkNext)), Querylike q ->
                 let next = mkNext QueryStatement
                 let w = x.Compile().Invoke
-                async { let! q' = q in return q' |> Seq.mapi tuple |> Seq.filter (snd >> w) }
+                let mkSelection q' = 
+                    if q' |> Seq.exists w |> not then mkDefault x |> New |> Seq.singleton 
+                    else q' |> Seq.mapi tuple |> Seq.filter (snd >> w) |> Seq.map Existing
+                async { let! q' = q in return mkSelection q' }
                 |> (Selection >> tuple next >> recurse)
             
             | Clause(Where(x, mkNext)), Selection q ->
                 let next = mkNext QueryStatement
                 let w = x.Compile().Invoke
-                async { let! q' = q in return q' |> Seq.filter (snd >> w) }
+                async { let! q' = q in return q' |> Seq.filter (Selection.filterExistingValue w) }
                 |> (Selection >> tuple next >> recurse)
             
             | Clause(Select(x, mkNext)), Querylike q -> 
                 let next = mkNext QueryStatement
                 let sel = x.Compile().Invoke
-                async { let! q' = q in return q' |> Seq.mapi (fun i v -> i,sel v) }
+                async { let! q' = q in return q' |> Seq.mapi (fun i v -> Existing (i,sel v)) }
                 |> (Selection >> tuple next >> recurse)
             
             | Clause(Select(x, mkNext)), Selection q -> 
                 let next = mkNext QueryStatement
                 let sel = x.Compile().Invoke
-                async { let! q' = q in return q' |> Seq.map (fun (i,v) -> i,sel v) }
+                async { let! q' = q in return q' |> Seq.map (Selection.map sel) }
                 |> (Selection >> tuple next >> recurse)
             
             | Clause(UpdateIf(x, mkNext)), Selection q -> 
@@ -73,15 +111,17 @@ module Interpreter =
                 let iff = x.Compile().Invoke
                 async { 
                     let! q' = q
-                    let res = q' |> Seq.filter (fun (i,_) -> iff source.[i]) |> List.ofSeq
-                    res |> List.iter (fun (i,v) -> source.[i] <- v)
+                    let res = q' |> Seq.filter (Selection.filterExistingIndex (fun i -> iff source.[i])) |> List.ofSeq
+                    res |> List.iter (Selection.iterExisting (fun (i,v) -> source.[i] <- v))
                 } |> (Command >> tuple next >> recurse)
             
             | Clause(Update(mkNext)), Selection q -> 
                 let next = mkNext CommandStatement
                 async { 
                     let! q' = q
-                    q' |> List.ofSeq |> List.iter (fun (i,v) -> source.[i] <- v)
+                    q' 
+                    |> List.ofSeq 
+                    |> List.iter (function | Existing (i,v) -> source.[i] <- v | New v -> source.Add v)
                 } |> (Command >> tuple next >> recurse)
             
             | Clause(Delete(mkNext)), Querylike q -> 
@@ -96,7 +136,7 @@ module Interpreter =
                 let next = mkNext CommandStatement
                 async { 
                     let! q' = q
-                    let res = q' |> Seq.sortByDescending fst |> List.ofSeq
+                    let res = q' |> Seq.choose Selection.existing |> Seq.sortByDescending fst |> List.ofSeq
                     res |> List.iter (fst >> source.RemoveAt)
                 } |> (Command >> tuple next >> recurse)
             
@@ -119,7 +159,7 @@ module Interpreter =
             | Clause(Count(mkNext)), Selection q -> 
                 let next = async {
                                 let! q' = q
-                                return q' |> Seq.length |> int64 
+                                return q' |> Seq.choose Selection.existing |> Seq.length |> int64 
                            } |> mkNext
                 recurse (next,Done) 
             
@@ -130,7 +170,7 @@ module Interpreter =
             | Clause(Read(mkNext)), Selection q -> 
                 let next = async {
                                 let! q' = q
-                                return q' |> Seq.map snd
+                                return q' |> Seq.choose Selection.existing |> Seq.map snd
                             } |> mkNext
                 recurse (next,Done) 
             
@@ -144,7 +184,7 @@ module Interpreter =
             | Clause(Find(mkNext)), Selection q -> 
                 let next = async {
                                 let! q' = q 
-                                return q' |> Seq.map snd |> Seq.tryHead
+                                return q' |> Seq.choose Selection.existing |> Seq.map snd |> Seq.tryHead
                            } |> mkNext
                 recurse (next,Done) 
             

--- a/src/FsCassy/InMem.fs
+++ b/src/FsCassy/InMem.fs
@@ -30,7 +30,7 @@ module Interpreter =
             | (:? ConstantExpression as ce), (:? MemberExpression as me) -> [ me.Member.Name, ce.Value ]
 
             | (:? UnaryExpression as ue), (:? ConstantExpression as ce)
-            | (:? ConstantExpression as ce), (:? UnaryExpression as ue) -> (ue.Operand |> unbox<MemberExpression>, ce) |> parseMemberValues // [ (unbox<MemberExpression> ue.Operand).Member.Name, ce.Value ]
+            | (:? ConstantExpression as ce), (:? UnaryExpression as ue) -> (ue.Operand |> unbox<MemberExpression>, ce) |> parseMemberValues
 
             | e1, e2 -> failwith <| sprintf "Unsupported binary expression: %O %O" e1 e2
 


### PR DESCRIPTION
Fix for #2 

A bit more complicated than originally thought but is now working.

* Where clause now creates records that don't exist
* Update clause adds new records to the `ResizeArray`
* Needed another level of control to differentiate between new and existing records to subsequent clauses 
  * So that queries like `where >>= read` or `where >>= find` don't return newly created records

With respect to expression parsing, it seems like you can [go from Quotation to Expression](https://stackoverflow.com/questions/2682475/converting-f-quotations-into-linq-expressions) but not the other way? I implemented some base use-case expressions but others may need to be supported in the future.